### PR TITLE
Add release drafter and pull request labeler

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,4 @@
+feature: ['features/*', 'feature/*', 'feat/*', 'features-*', 'feature-*', 'feat-*']
+fix: ['fixes/*', 'fix/*']
+chore: ['chore/*']
+dependencies: ['update/*']

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,40 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+  - title: "🧹 Maintenance"
+    labels:
+      - "maintenance"
+      - "dependencies"
+      - "refactoring"
+      - "cosmetic"
+      - "chore"
+  - title: "📝️ Documentation"
+    labels:
+      - "documentation"
+      - "docs"
+change-template: "- $TITLE (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,0 +1,20 @@
+# Drafts the next Release notes as Pull Requests are merged (or commits are pushed) into "main" or "master"
+name: Draft next release
+
+on:
+  push:
+    branches: [main, "master"]
+
+permissions:
+  contents: read
+
+jobs:
+  update-release-draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -1,0 +1,17 @@
+# This workflow will apply the corresponding label on a pull request
+name: PR Labeler
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v4
+        with:
+          repo-token: ${{ github.token }}


### PR DESCRIPTION
# What does this PR do?

This pull request add a [release drafter](https://github.com/release-drafter/release-drafter) and a pull request labeler based on branch names.

The release drafter helps to automatically draft a new release when a commit is pushed to the `main` branch.
The pull request labeler will automatically add a corresponding label to a pull request based on its branch name. These labels are also taken into account by the release drafter (as explain in its readme).

Thank you