### PR TITLE
Update on MLC Prompt

### DIFF
--- a/skllm/openai/prompts.py
+++ b/skllm/openai/prompts.py
@@ -26,7 +26,7 @@ def get_zero_shot_prompt_mlc(x, labels, max_cats):
         "",
         "Perform the following tasks:",
         "1. Identify to which categories the provided text belongs to with the highest probability.",
-        f"2. Assign the text sample to up to {max_cats} categories based on the probabilities.",
+        f"2. Assign the text sample to up to {max_cats} of these categories based on the probabilities.",
         "3. Provide your response in a JSON format containing a single key `label` and a value corresponding to the list of assigned categories. Do not provide any additional information except the JSON."
         "\n", 
         f"List of categories: {repr(labels)}"

--- a/skllm/openai/prompts.py
+++ b/skllm/openai/prompts.py
@@ -26,7 +26,7 @@ def get_zero_shot_prompt_mlc(x, labels, max_cats):
         "",
         "Perform the following tasks:",
         "1. Identify to which categories the provided text belongs to with the highest probability.",
-        f"2. Assign the text sample to at least 1 but up to {max_cats} categories based on the probabilities.",
+        f"2. Assign the text sample to up to {max_cats} categories based on the probabilities.",
         "3. Provide your response in a JSON format containing a single key `label` and a value corresponding to the list of assigned categories. Do not provide any additional information except the JSON."
         "\n", 
         f"List of categories: {repr(labels)}"


### PR DESCRIPTION
Hey there, 

I think that in this line: https://github.com/iryna-kondr/scikit-llm/blob/6b0d5f5466cb48a9622b6eb8a60dfe9dc0446b2d/skllm/openai/prompts.py#L29 there is a mistake. A new unknown instance can be classified to zero labels as well. However, the current implementation pushes ChatGPT to choose at least on label (category). It should be rephrased as suggested in the PR, or with something similar to this.

Best regards