### PR TITLE
add support for Claude, Cohere, Replicate

### DIFF
--- a/skllm/models/gpt/gpt_zero_shot_clf.py
+++ b/skllm/models/gpt/gpt_zero_shot_clf.py
@@ -3,7 +3,6 @@ from typing import List, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
-
 from skllm.models._base import _BaseZeroShotGPTClassifier
 from skllm.prompts.builders import (
     build_zero_shot_prompt_mlc,

--- a/skllm/openai/chatgpt.py
+++ b/skllm/openai/chatgpt.py
@@ -1,7 +1,8 @@
 from time import sleep
 
 import openai
-
+import litellm 
+from litellm import completion
 from skllm.openai.credentials import set_azure_credentials, set_credentials
 
 
@@ -65,7 +66,7 @@ def get_chat_completion(
     error_type = None
     for _ in range(max_retries):
         try:
-            completion = openai.ChatCompletion.create(
+            completion = completion(api_key=key,
                 temperature=0.0, messages=messages, **model_dict
             )
             return completion


### PR DESCRIPTION
Hi @OKUA1 @iryna-kondr ,

Saw you expanded support to PaLM - and wanted to see how to add support for other LLM providers. I'm working on litellm (simple library to standardize LLM API Calls - https://github.com/BerriAI/litellm) and was wondering if we could be helpful.

Added support for Anthropic, Llama2, and Cohere by replacing the raw openai.chatCompletion.create function with completion. The code is pretty similar to the OpenAI class - as litellm follows the same pattern as the openai-python sdk.

Would love to know if this helps.