### PR TITLE
Add support for Llama2, Palm, Cohere, Replicate Models - using litellm 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
   "scikit-learn>=1.1.0",
   "pandas>=1.5.0",
   "openai>=0.27.0",
+  "litellm>=0.1.385",
   "tqdm>=4.60.0",
   "annoy>=1.17.2",
   "google-cloud-aiplatform>=1.27.0"

--- a/skllm/openai/chatgpt.py
+++ b/skllm/openai/chatgpt.py
@@ -1,6 +1,7 @@
 from time import sleep
 
 import openai
+import litellm
 
 from skllm.openai.credentials import set_azure_credentials, set_credentials
 
@@ -65,7 +66,7 @@ def get_chat_completion(
     error_type = None
     for _ in range(max_retries):
         try:
-            completion = openai.ChatCompletion.create(
+            completion = litellm.completion(
                 temperature=0.0, messages=messages, **model_dict
             )
             return completion


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

Here's a sample of how it's used:

```
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# llama2 call
model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
response = completion(model_name, messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```