### PR TITLE
added optional distance metric for KNN in DynamicFewShotGPTClassifier

### DIFF
--- a/skllm/models/_base/classifier.py
+++ b/skllm/models/_base/classifier.py
@@ -351,6 +351,7 @@ class BaseDynamicFewShotClassifier(BaseClassifier):
         memory_index: Optional[IndexConstructor] = None,
         vectorizer: _BaseVectorizer = None,
         prompt_template: Optional[str] = None,
+        metric="euclidean",
     ):
         super().__init__(
             model=model,
@@ -360,6 +361,7 @@ class BaseDynamicFewShotClassifier(BaseClassifier):
         self.vectorizer = vectorizer
         self.memory_index = memory_index
         self.n_examples = n_examples
+        self.metric = metric
         if isinstance(self, MultiLabelMixin):
             raise TypeError("Multi-label classification is not supported")
 
@@ -402,7 +404,7 @@ class BaseDynamicFewShotClassifier(BaseClassifier):
                 index = self.memory_index()
                 index.dim = embeddings.shape[1]
             else:
-                index = SklearnMemoryIndex(embeddings.shape[1])
+                index = SklearnMemoryIndex(embeddings.shape[1], metric=self.metric)
             for embedding in embeddings:
                 index.add(embedding)
             index.build()

--- a/skllm/models/gpt/classification/few_shot.py
+++ b/skllm/models/gpt/classification/few_shot.py
@@ -100,6 +100,7 @@ class DynamicFewShotGPTClassifier(
         n_examples: int = 3,
         memory_index: Optional[IndexConstructor] = None,
         vectorizer: Optional[BaseVectorizer] = None,
+        metric: Optional[str] = "euclidean",
         **kwargs,
     ):
         """
@@ -124,6 +125,8 @@ class DynamicFewShotGPTClassifier(
             custom memory index, for details check `skllm.memory` submodule, by default None
         vectorizer : Optional[BaseVectorizer], optional
             scikit-llm vectorizer; if None, `GPTVectorizer` is used, by default None
+        metric : Optional[str], optional
+            metric used for similarity search, by default "euclidean"
         """
         if vectorizer is None:
             vectorizer = GPTVectorizer(model="text-embedding-ada-002")
@@ -134,5 +137,6 @@ class DynamicFewShotGPTClassifier(
             n_examples=n_examples,
             memory_index=memory_index,
             vectorizer=vectorizer,
+            metric=metric,
         )
         self._set_keys(key, org)


### PR DESCRIPTION
People should be able to use different distance metrics for the `DynamicFewShotGPTClassifier`. According to [this](https://stackoverflow.com/a/77852956) SO answer we should use the same similarity metric that of the model. E.g. cosine for openai.
I simply propagated the `metric` variable up to `DynamicFewShotGPTClassifier` and tested it with the example from the documentation.

