### PR TITLE
Attributes

### DIFF
--- a/skllm/llm/gpt/mixin.py
+++ b/skllm/llm/gpt/mixin.py
@@ -70,10 +70,6 @@ class GPTMixin:
         self.key = key
         self.org = org
         
-        if self.key is None:
-            self.key = self._get_openai_key()
-        if org is None:
-            self.org = self._get_openai_org()
 
     def _get_openai_key(self) -> str:
         """
@@ -83,12 +79,12 @@ class GPTMixin:
         -------
         openai_key: str
         """
-        openai_key = self.key
-        if openai_key is None:
-            openai_key = _Config.get_openai_key()
-        if openai_key is None:
+        key = self.key
+        if key is None:
+            key = _Config.get_openai_key()
+        if key is None:
             raise RuntimeError("OpenAI key was not found")
-        return openai_key
+        return key
 
     def _get_openai_org(self) -> str:
         """
@@ -98,12 +94,12 @@ class GPTMixin:
         -------
         openai_org: str
         """
-        openai_org = self.org
-        if openai_org is None:
-            openai_org = _Config.get_openai_org()
-        if openai_org is None:
+        org = self.org
+        if org is None:
+            org = _Config.get_openai_org()
+        if org is None:
             raise RuntimeError("OpenAI organization was not found")
-        return openai_org
+        return org
 
 
 class GPTTextCompletionMixin(GPTMixin, BaseTextCompletionMixin):
@@ -218,7 +214,7 @@ class GPTEmbeddingMixin(GPTMixin, BaseEmbeddingMixin):
 
 # for now this works only with OpenAI
 class GPTTunableMixin(BaseTunableMixin):
-    _supported_tunable_models = ["gpt-3.5-turbo-0613", "gpt-3.5-turbo"]
+    _supported_tunable_models = ["gpt-3.5-turbo-0125", "gpt-3.5-turbo"]
 
     def _build_label(self, label: str):
         return json.dumps({"label": label})

--- a/skllm/llm/gpt/mixin.py
+++ b/skllm/llm/gpt/mixin.py
@@ -66,8 +66,14 @@ class GPTMixin:
         """
         Set the OpenAI key and organization.
         """
-        self.openai_key = key
-        self.openai_org = org
+            
+        self.key = key
+        self.org = org
+        
+        if self.key is None:
+            self.key = self._get_openai_key()
+        if org is None:
+            self.org = self._get_openai_org()
 
     def _get_openai_key(self) -> str:
         """
@@ -77,12 +83,12 @@ class GPTMixin:
         -------
         openai_key: str
         """
-        key = self.openai_key
-        if key is None:
-            key = _Config.get_openai_key()
-        if key is None:
+        openai_key = self.key
+        if openai_key is None:
+            openai_key = _Config.get_openai_key()
+        if openai_key is None:
             raise RuntimeError("OpenAI key was not found")
-        return key
+        return openai_key
 
     def _get_openai_org(self) -> str:
         """
@@ -92,12 +98,12 @@ class GPTMixin:
         -------
         openai_org: str
         """
-        key = self.openai_org
-        if key is None:
-            key = _Config.get_openai_org()
-        if key is None:
+        openai_org = self.org
+        if openai_org is None:
+            openai_org = _Config.get_openai_org()
+        if openai_org is None:
             raise RuntimeError("OpenAI organization was not found")
-        return key
+        return openai_org
 
 
 class GPTTextCompletionMixin(GPTMixin, BaseTextCompletionMixin):
@@ -212,7 +218,7 @@ class GPTEmbeddingMixin(GPTMixin, BaseEmbeddingMixin):
 
 # for now this works only with OpenAI
 class GPTTunableMixin(BaseTunableMixin):
-    _supported_tunable_models = ["gpt-3.5-turbo-0125", "gpt-3.5-turbo"]
+    _supported_tunable_models = ["gpt-3.5-turbo-0613", "gpt-3.5-turbo"]
 
     def _build_label(self, label: str):
         return json.dumps({"label": label})

--- a/skllm/llm/gpt/mixin.py
+++ b/skllm/llm/gpt/mixin.py
@@ -77,7 +77,7 @@ class GPTMixin:
 
         Returns
         -------
-        openai_key: str
+        key: str
         """
         key = self.key
         if key is None:
@@ -92,7 +92,7 @@ class GPTMixin:
 
         Returns
         -------
-        openai_org: str
+        org: str
         """
         org = self.org
         if org is None:

--- a/skllm/models/gpt/classification/few_shot.py
+++ b/skllm/models/gpt/classification/few_shot.py
@@ -129,7 +129,7 @@ class DynamicFewShotGPTClassifier(
             metric used for similarity search, by default "euclidean"
         """
         if vectorizer is None:
-            vectorizer = GPTVectorizer(model="text-embedding-ada-002")
+            vectorizer = GPTVectorizer(model="text-embedding-ada-002", key=key, org=org)
         super().__init__(
             model=model,
             default_label=default_label,


### PR DESCRIPTION
Fixes #93. Also propagates key, org to the vectorizer at an earlier stage if it is set through the model.
However key, org might be more easily exposed.
At the same time currently it is possible to set key, org like below which still exposed them through `__dict__`.

~~~python
from skllm.models.gpt.classification.zero_shot import ZeroShotGPTClassifier
from skllm.datasets import get_classification_dataset
from skllm.config import SKLLMConfig

API_KEY="..."
SKLLMConfig.set_openai_key(API_KEY)

# demo sentiment analysis dataset
# labels: positive, negative, neutral
X, y = get_classification_dataset()

clf = ZeroShotGPTClassifier(model="gpt-3.5-turbo", key=API_KEY)
clf.__dict__ # exposes API_KEY - old version also exposes API_KEY
# {'model': 'gpt-3.5-turbo', 'default_label': 'Random', 'prompt_template': None, 'openai_key': '...', 'openai_org': None}
clf # exposes API_KEY - old version threw error
~~~