### PR TITLE
Fix prompt typo templates.py

### DIFF
--- a/skllm/prompts/templates.py
+++ b/skllm/prompts/templates.py
@@ -192,7 +192,7 @@ Input:
 {x}
 ```
 
-Output (origina text with tags):
+Output (original text with tags):
 """
 
 


### PR DESCRIPTION
Quick typo fix in prompt. `origina` to `original`